### PR TITLE
Catch network errors so it can be handled elsewhere

### DIFF
--- a/src/subscription-link.ts
+++ b/src/subscription-link.ts
@@ -83,7 +83,8 @@ function createRequestHandler(echoClient: Echo): RequestHandler {
           operation,
           observer,
           (name) => (channelName = name)
-        )
+        ),
+        error => observer.error(error)
       );
 
       return () => unsubscribe(echoClient, () => channelName);


### PR DESCRIPTION
When the subscription link is added is creates an uncaught error which stops the error being handled by other links in the chain (such as RetryLink). This is resolved by utilising the error callback in the observable.