### PR TITLE
Update subscription-link.ts

### DIFF
--- a/src/subscription-link.ts
+++ b/src/subscription-link.ts
@@ -56,11 +56,11 @@ function createSubscriptionHandler(
       data?.extensions?.lighthouse_subscriptions?.version;
 
     const channelName: string | null =
-      lighthouseVersion == 2
-        ? data?.extensions?.lighthouse_subscriptions?.channel
-        : data?.extensions?.lighthouse_subscriptions?.channels?.[
+      lighthouseVersion == 1
+        ? data?.extensions?.lighthouse_subscriptions?.channels?.[
             subscriptionName
-          ];
+          ]
+        : data?.extensions?.lighthouse_subscriptions?.channel;
 
     if (channelName) {
       setChannelName(channelName);


### PR DESCRIPTION
Latest version of lighthouse doesn't a version in response causing it to select v1, which will make the channel name undefined, this fixes that.